### PR TITLE
ISSUE-96:decrease election timeout and AE timeout

### DIFF
--- a/src/infra/raft/RaftConstants.h
+++ b/src/infra/raft/RaftConstants.h
@@ -22,13 +22,13 @@ namespace raft {
 
 struct RaftConstants {
   /// The minimum/maximum timeout follower will wait before starting a new election
-  static constexpr uint64_t kMinElectionTimeoutInMillis = 1000;
+  static constexpr uint64_t kMinElectionTimeoutInMillis = 200;
   static constexpr uint64_t kMaxElectionTimeoutInMillis = kMinElectionTimeoutInMillis * 2;
 
   /// heart beat interval that leader will wait before sending a heartbeat to follower
   static const uint64_t kHeartBeatIntervalInMillis = 10;
 
-  struct AppendEntries { static constexpr uint64_t kRpcTimeoutInMillis = 300; };
+  struct AppendEntries { static constexpr uint64_t kRpcTimeoutInMillis = 100; };
   struct RequestVote   { static constexpr uint64_t kRpcTimeoutInMillis = 100; };
 };
 


### PR DESCRIPTION
decrease election timeout to 200~400ms, and AE timeout to 100ms according to network situation