### PR TITLE
ISSUE-124: make raft parameters configurable

### DIFF
--- a/src/infra/raft/v2/RaftCore.h
+++ b/src/infra/raft/v2/RaftCore.h
@@ -255,8 +255,8 @@ class RaftCore : public RaftInterface {
   /// 3) become Follower
   /// 4) become Candidate
   void updateElectionTimePoint() {
-    auto timeIntervalInNano = RandomUtil::randomRange(RaftConstants::kMinElectionTimeoutInMillis * 1000 * 1000,
-                                                      RaftConstants::kMaxElectionTimeoutInMillis * 1000 * 1000);
+    auto timeIntervalInNano = RandomUtil::randomRange(mMinElectionTimeoutInMillis * 1000 * 1000,
+                                                      mMaxElectionTimeoutInMillis * 1000 * 1000);
     mElectionTimePointInNano = TimeUtil::currentTimeInNanos() + timeIntervalInNano;
   }
 
@@ -281,6 +281,14 @@ class RaftCore : public RaftInterface {
   /**
    * configurable vars
    */
+  /// heart beat interval that leader will wait before sending a heartbeat to follower
+  uint64_t mHeartBeatIntervalInMillis = RaftConstants::kHeartBeatIntervalInMillis;
+  /// the minimum/maximum timeout follower will wait before starting a new election
+  uint64_t mMinElectionTimeoutInMillis = RaftConstants::kMinElectionTimeoutInMillis;
+  uint64_t mMaxElectionTimeoutInMillis = RaftConstants::kMaxElectionTimeoutInMillis;
+  /// the timeout for RPCs
+  uint64_t mRpcAppendEntriesTimeoutInMillis = RaftConstants::AppendEntries::kRpcTimeoutInMillis;
+  uint64_t mRpcRequestVoteTimeoutInMillis = RaftConstants::RequestVote::kRpcTimeoutInMillis;
   /// for getEntries()
   uint64_t mMaxBatchSize = 2000;
   uint64_t mMaxLenInBytes = 5000000;

--- a/src/infra/raft/v2/RaftService.h
+++ b/src/infra/raft/v2/RaftService.h
@@ -268,7 +268,9 @@ class RaftClient {
              std::optional<TlsConf> tlsConfOpt,
              std::shared_ptr<DNSResolver> dnsResolver,
              uint64_t peerId,
-             EventQueue *aeRvQueue);
+             EventQueue *aeRvQueue,
+             uint64_t rpcAppendEntriesTimeoutInMillis = RaftConstants::AppendEntries::kRpcTimeoutInMillis,
+             uint64_t rpcRequestVoteTimeoutInMillis = RaftConstants::RequestVote::kRpcTimeoutInMillis);
   ~RaftClient();
 
   void requestVote(const RequestVote::Request &request);
@@ -287,6 +289,8 @@ class RaftClient {
   std::unique_ptr<Raft::Stub> mStub;
   std::shared_mutex mMutex;  /// the lock to guarantee thread-safe access of mStub
   grpc::CompletionQueue mCompletionQueue;
+  uint64_t mRpcAppendEntriesTimeoutInMillis;
+  uint64_t mRpcRequestVoteTimeoutInMillis;
 
   /// event queue
   EventQueue *mAeRvQueue;


### PR DESCRIPTION
Support 5 new configure variables in 'raft.default' section in raft config file:
| config name                           | description                                                                     | default value |
| ------------------------------------- | ------------------------------------------------------------------------------- | ------------- |
| `heartbeat.interval.millis`         | heartbeat interval that leader will wait before sending a heartbeat to follower | 10            |
| `min.election.timeout.millis`       | the minimum timeout follower will wait before starting a new election           | 500           |
| `max.election.timeout.millis`       | the maximum timeout follower will wait before starting a new election           | 1000          |
| `rpc.append.entries.timeout.millis` | the timeout for AppendEntries RPC                                               | 300           |
| `rpc.request.vote.timeout.millis`   | the timeout for RequestVote RPC                                                 | 100           |

